### PR TITLE
Fix permissions when getting the executable path

### DIFF
--- a/static_ffmpeg/run.py
+++ b/static_ffmpeg/run.py
@@ -12,26 +12,28 @@ import static_ffmpeg
 PCKG_PATH = static_ffmpeg.__path__[0]  # type: ignore  # mypy issue #1422
 
 
-def get_platform_executable_or_raise():
+def get_platform_executable_or_raise(fix_permissions=True):
     """Either get the executable or raise an error"""
     if sys.platform == "win32":
-        return os.path.join(PCKG_PATH, "win32", "ffmpeg.exe")
-    if sys.platform == "linux":
-        return os.path.join(PCKG_PATH, "linux", "ffmpeg")
-    if sys.platform == "darwin":
-        return os.path.join(PCKG_PATH, "macos_x64", "ffmpeg")
-    raise OSError(f"Please implement static_ffmpeg for {sys.platform}")
+        ffmpeg_exe = os.path.join(PCKG_PATH, "win32", "ffmpeg.exe")
+    elif sys.platform == "linux":
+        ffmpeg_exe = os.path.join(PCKG_PATH, "linux", "ffmpeg")
+    elif sys.platform == "darwin":
+        ffmpeg_exe = os.path.join(PCKG_PATH, "macos_x64", "ffmpeg")
+    else:
+        raise OSError(f"Please implement static_ffmpeg for {sys.platform}")
+
+    if fix_permissions and sys.platform != 'win32' and not os.access(ffmpeg_exe, os.X_OK):
+        mode = stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP
+        os.chmod(ffmpeg_exe, mode)
+        assert os.access(ffmpeg_exe, os.X_OK), f'Could not execute {ffmpeg_exe}'
+    return ffmpeg_exe
 
 
 def main():
     """Entry point for running static_ffmpeg, which delegates to ffmpeg."""
     ffmpeg_exe = get_platform_executable_or_raise()
     str_args = " ".join(sys.argv[1:])
-    if sys.platform != 'win32':
-        if not os.access(ffmpeg_exe, os.X_OK):
-            mode = stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP
-            os.chmod(ffmpeg_exe, mode)
-            assert os.access(ffmpeg_exe, os.X_OK), f'Could not execute {ffmpeg_exe}'
     cmd = f"{ffmpeg_exe} {str_args}"
     rtn = os.system(cmd)
     sys.exit(rtn)

--- a/tests/test_static_ffmpeg.py
+++ b/tests/test_static_ffmpeg.py
@@ -11,6 +11,9 @@ class static_ffmpegTester(unittest.TestCase):
     def test_platform_executable(self) -> None:
         run.get_platform_executable_or_raise()
 
+    def test_no_fix_permissions(self) -> None:
+        run.get_platform_executable_or_raise(False)
+
     def test_run_static_ffmpeg(self) -> None:
         subprocess.check_output(['static_ffmpeg', '-version'])
 


### PR DESCRIPTION
I would like a way to fix permissions for the executable without running it through the provided interface. I expect others may want this as well, such as tying it into pydub, etc.