### PR TITLE
Add static_ffmpeg bin dir to os.environ

### DIFF
--- a/static_ffmpeg/__init__.py
+++ b/static_ffmpeg/__init__.py
@@ -1,0 +1,10 @@
+import os
+from .run import get_platform_executable_or_raise
+
+__all__ = ['get_platform_executable_or_raise']
+
+try:
+    dir = get_platform_executable_or_raise()
+    os.environ["PATH"] += os.pathsep + os.path.dirname(dir)
+except:
+    raise RuntimeError(f"Failed to add static_ffmpeg path {dir} to the system path")

--- a/tests/test_static_ffmpeg.py
+++ b/tests/test_static_ffmpeg.py
@@ -1,3 +1,4 @@
+import shutil
 import unittest
 import subprocess
 
@@ -21,10 +22,15 @@ class static_ffmpegTester(unittest.TestCase):
 import os
 import stat
 import subprocess
-import sys
+import sys, os
 import unittest
 
 from static_ffmpeg import run
+import static_ffmpeg
+
+
+def test_check_path() -> None:
+    assert shutil.which("ffmpeg") is not None
 
 
 class static_ffmpegTester(unittest.TestCase):
@@ -33,14 +39,14 @@ class static_ffmpegTester(unittest.TestCase):
         self.cleanup = []
 
     def test_platform_executable(self) -> None:
-        run.get_platform_executable_or_raise()
+        static_ffmpeg.get_platform_executable_or_raise()
 
     def test_run_static_ffmpeg(self) -> None:
         subprocess.check_output(["static_ffmpeg", "-version"])
 
     @unittest.skipIf(sys.platform == "win32", "Only valid for macos and linux")
     def test_permission_bits(self) -> None:
-        ffmpeg_exe = run.get_platform_executable_or_raise()
+        ffmpeg_exe = static_ffmpeg.get_platform_executable_or_raise()
         mode = os.stat(ffmpeg_exe).st_mode
         exe_bits = stat.S_IXOTH | stat.S_IXUSR | stat.S_IXGRP
         read_bits = stat.S_IRUSR | stat.S_IRGRP | stat.S_IXGRP


### PR DESCRIPTION
This is PR to address #5

Added `test_check_path()` to validate it working. All GitHub Actions passed successfully.

Also validated that this `os.environ` call does not alter the system path of the terminal/console session.
